### PR TITLE
[package.json]: downgrade to older react-scripts and sass versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postcss": "^8.4.12",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "^4.0.3"
   },
   "devDependencies": {
     "@cypress/webpack-dev-server": "^1.8.4",
@@ -31,7 +31,7 @@
     "mochawesome": "^7.1.3",
     "mochawesome-merge": "^4.2.0",
     "mochawesome-report-generator": "^6.2.0",
-    "node-sass": "^7.0.1",
+    "node-sass": "^6.0.1",
     "stylelint": "^13.13.1",
     "typescript": "^4.6.3"
   },


### PR DESCRIPTION
Downgrade to older `react-scripts` and `node-sass` package versions cause the new ones doesn't compatible with the old node version(14.18+)